### PR TITLE
5-academy-card-section - Last fixes for 1:1

### DIFF
--- a/ext/blocks/custom-text/custom-text.css
+++ b/ext/blocks/custom-text/custom-text.css
@@ -37,3 +37,8 @@
   letter-spacing: -1.8px;
   margin-bottom: var(--spacing-large);
 }
+
+.section.sticky-section > .custom-text-wrapper > .custom-text.block > div:last-child p {
+    margin-bottom: 0;
+    height: 58px;
+}


### PR DESCRIPTION
This only contains a small fix, the rest of the styling has been brought in through /pull/33 and 'intermediary commit' 8d00e82 (accidentally directly to main). 

Fix #5

Test URLs:
- Before: https://main--wbcopy--helms-charity.aem.page
- After: https://5-academy-card-section--wbcopy--helms-charity.aem.page
