### PR TITLE
Only show colors on homepage.

### DIFF
--- a/ext/scripts/scripts.js
+++ b/ext/scripts/scripts.js
@@ -40,6 +40,10 @@ function addColorWrapper() {
   if (main.querySelector('.color-wrapper')) {
     return;
   }
+  //check that the currently loaded page is the home page, by checking that .hero-video-section exists
+  if (!document.querySelector('.hero-video-section')) {
+    return;
+  }
   const colorWrapper = document.createElement('div');
   colorWrapper.classList.add('color-wrapper');
   main.insertBefore(colorWrapper, main.firstChild);


### PR DESCRIPTION
Colors shouldn't show on pages other than homepage (containing the .hero-video-section).

Fix #37 

Test URLs:
- Before: https://main--wbcopy--helms-charity.aem.page/library/video
- After: https://37-background-colors--wbcopy--helms-charity.aem.page/library/video
