### PR TITLE
fix indexing location

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -13,7 +13,7 @@ indices:
       - '/en/nav'
       - '/en/data'
       - '/en/data/**'
-    target: /en/query-index.json
+    target: /ext/en/query-index.json
     properties:
       title:
         select: head > meta[property="og:title"]


### PR DESCRIPTION
moved indexing location from /ext/en to /en, so that it points to the correct location.

Fix #89 

Test URLs:
- Before: https://main--wbcopy--helms-charity.aem.page
- After: https://89-breadcrumbs-fix--wbcopy--helms-charity.aem.page
